### PR TITLE
feat: allow setting KV cache type, remove deprecated F16KV

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -288,8 +288,9 @@ You can set the quantization type in a number of ways:
 2. In a model's Modelfile using the `cache_type_k` and `cache_type_v` parameters which will be loaded with the model.
 3. In the CLI with `/set parameter cache_type_k <value>` and `/set parameter cache_type_v <value>` which will be used for that session.
 
-While there are [a number of quantization types available](https://github.com/ggerganov/llama.cpp/pull/7527), the most common you might want to choose are:
+While there are [a number of quantization types available](https://github.com/ggerganov/llama.cpp/pull/7527), Ollama currently supports:
 
+- `f32` - full precision and memory usage.
 - `f16` - high precision and memory usage (default).
 - `q8_0` - 8-bit quantization, uses approximately 1/2 the memory of `f16` with a very small loss in precision.
 - `q4_0` - 4-bit quantization, uses approximately 1/4 the memory of `f16` with a small-medium loss in precision.

--- a/llm/memory.go
+++ b/llm/memory.go
@@ -312,12 +312,12 @@ func estimateKvCacheSize(cacheType string, numCtx, blockCount, embeddingHeadCoun
 	var bytesPerElement float64
 
 	switch cacheType {
+	case "f32", "fp32":
+		bytesPerElement = 4 // fp32
 	case "", "f16", "fp16":
 		bytesPerElement = 2 // fp16
-	case "q4_0", "q4_1", "iq4_nl":
+	case "q4_0":
 		bytesPerElement = 0.5 // 1/4 of fp16
-	case "q5_0", "q5_1":
-		bytesPerElement = 0.625 // 5/8 of fp16
 	case "q8_0":
 		bytesPerElement = 1 // 1/2 of fp16
 	default:

--- a/llm/server.go
+++ b/llm/server.go
@@ -97,7 +97,6 @@ func setCacheTypeParams(params *[]string, opts *api.Options, flashAttnEnabled bo
 	// K/V cache quantization types supported by llama.cpp server
 	validKVCacheTypes := map[string]bool{
 		"f16": true, "f32": true, "q8_0": true, "q4_0": true,
-		"q4_1": true, "q5_0": true, "q5_1": true, "iq4_nl": true,
 	}
 
 	setCacheTypeParam := func(paramName, cacheType string) {


### PR DESCRIPTION
- Add tests for memory estimates
- Limit supported k/v context cache types to f32, f16, q8_0, q4_0 for now