### PR TITLE
revert ability to set cache types by api, modelfile, cmd

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -231,18 +231,17 @@ type Options struct {
 
 // Runner options which must be set when the model is loaded into memory
 type Runner struct {
-	NumCtx     int    `json:"num_ctx,omitempty"`
-	NumBatch   int    `json:"num_batch,omitempty"`
-	NumGPU     int    `json:"num_gpu,omitempty"`
-	MainGPU    int    `json:"main_gpu,omitempty"`
-	LowVRAM    bool   `json:"low_vram,omitempty"`
-	LogitsAll  bool   `json:"logits_all,omitempty"`
-	VocabOnly  bool   `json:"vocab_only,omitempty"`
-	UseMMap    *bool  `json:"use_mmap,omitempty"`
-	UseMLock   bool   `json:"use_mlock,omitempty"`
-	NumThread  int    `json:"num_thread,omitempty"`
-	CacheTypeK string `json:"cache_type_k,omitempty"`
-	CacheTypeV string `json:"cache_type_v,omitempty"`
+	NumCtx    int   `json:"num_ctx,omitempty"`
+	NumBatch  int   `json:"num_batch,omitempty"`
+	NumGPU    int   `json:"num_gpu,omitempty"`
+	MainGPU   int   `json:"main_gpu,omitempty"`
+	LowVRAM   bool  `json:"low_vram,omitempty"`
+	F16KV     bool  `json:"f16_kv,omitempty"`
+	LogitsAll bool  `json:"logits_all,omitempty"`
+	VocabOnly bool  `json:"vocab_only,omitempty"`
+	UseMMap   *bool `json:"use_mmap,omitempty"`
+	UseMLock  bool  `json:"use_mlock,omitempty"`
+	NumThread int   `json:"num_thread,omitempty"`
 }
 
 // EmbedRequest is the request passed to [Client.Embed].
@@ -612,6 +611,7 @@ func DefaultOptions() Options {
 			NumGPU:    -1, // -1 here indicates that NumGPU should be set dynamically
 			NumThread: 0,  // let the runtime decide
 			LowVRAM:   false,
+			F16KV:     true,
 			UseMLock:  false,
 			UseMMap:   nil,
 		},

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1125,17 +1125,6 @@ func generate(cmd *cobra.Command, opts runOptions) error {
 		fmt.Println()
 	}
 
-	// Ensure CacheTypeK and CacheTypeV are set in the request options
-	if opts.Options == nil {
-		opts.Options = make(map[string]interface{})
-	}
-	if _, ok := opts.Options["cache_type_k"]; !ok {
-		opts.Options["cache_type_k"] = envconfig.CacheTypeK()
-	}
-	if _, ok := opts.Options["cache_type_v"]; !ok {
-		opts.Options["cache_type_v"] = envconfig.CacheTypeV()
-	}
-
 	if !latest.Done {
 		return nil
 	}
@@ -1428,8 +1417,6 @@ func NewCLI() *cobra.Command {
 				envVars["OLLAMA_SCHED_SPREAD"],
 				envVars["OLLAMA_TMPDIR"],
 				envVars["OLLAMA_FLASH_ATTENTION"],
-				envVars["OLLAMA_CACHE_TYPE_K"],
-				envVars["OLLAMA_CACHE_TYPE_V"],
 				envVars["OLLAMA_LLM_LIBRARY"],
 			})
 		default:

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1417,6 +1417,8 @@ func NewCLI() *cobra.Command {
 				envVars["OLLAMA_SCHED_SPREAD"],
 				envVars["OLLAMA_TMPDIR"],
 				envVars["OLLAMA_FLASH_ATTENTION"],
+				envVars["OLLAMA_CACHE_TYPE_K"],
+				envVars["OLLAMA_CACHE_TYPE_V"],
 				envVars["OLLAMA_LLM_LIBRARY"],
 			})
 		default:

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -128,8 +128,6 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		fmt.Fprintln(os.Stderr, "  /set parameter repeat_last_n <int>    Set how far back to look for repetitions")
 		fmt.Fprintln(os.Stderr, "  /set parameter num_gpu <int>          The number of layers to send to the GPU")
 		fmt.Fprintln(os.Stderr, "  /set parameter stop <string> <string> ...   Set the stop parameters")
-		fmt.Fprintln(os.Stderr, "  /set parameter cache_type_k <string>  Set the key cache type")
-		fmt.Fprintln(os.Stderr, "  /set parameter cache_type_v <string>  Set the value cache type")
 		fmt.Fprintln(os.Stderr, "")
 	}
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -255,7 +255,7 @@ curl http://localhost:11434/api/generate -d '{
 
 #### Response
 
-```json
+```
 {
   "model": "llava",
   "created_at": "2023-11-03T15:36:02.583064Z",
@@ -355,6 +355,7 @@ curl http://localhost:11434/api/generate -d '{
     "num_gpu": 1,
     "main_gpu": 0,
     "low_vram": false,
+    "f16_kv": true,
     "vocab_only": false,
     "use_mmap": true,
     "use_mlock": false,

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -285,11 +285,12 @@ Installing multiple GPUs of the same brand can be a great way to increase your a
 
 The K/V context cache can be quantized to significantly reduce memory usage when Flash Attention is enabled.
 
-You can set the quantization type in a number of ways:
+Currently you to use quantized k/v cache with Ollama you must set the following environment variables:
 
-1. In the environment using `OLLAMA_CACHE_TYPE_K` and `OLLAMA_CACHE_TYPE_V` which will be the default vault for all models loaded.
-2. In a model's Modelfile using the `cache_type_k` and `cache_type_v` parameters which will be loaded with the model.
-3. In the CLI with `/set parameter cache_type_k <value>` and `/set parameter cache_type_v <value>` which will be used for that session.
+- `OLLAMA_CACHE_TYPE_K` - The quantization type for the key cache.  Default is `f16`.
+- `OLLAMA_CACHE_TYPE_V` - The quantization type for the value cache.  Default is `f16`.
+
+Warning: This is a global option - meaning all your models will be affected by this setting.
 
 While there are [a number of quantization types available](https://github.com/ggerganov/llama.cpp/pull/7527), Ollama currently supports:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -285,12 +285,12 @@ Installing multiple GPUs of the same brand can be a great way to increase your a
 
 The K/V context cache can be quantized to significantly reduce memory usage when Flash Attention is enabled.
 
-Currently you to use quantized k/v cache with Ollama you must set the following environment variables:
+To use quantized k/v cache with Ollama you can set the following environment variables:
 
 - `OLLAMA_CACHE_TYPE_K` - The quantization type for the key cache.  Default is `f16`.
 - `OLLAMA_CACHE_TYPE_V` - The quantization type for the value cache.  Default is `f16`.
 
-Warning: This is a global option - meaning all your models will be affected by this setting.
+Note: Currently this is a global option - meaning all models will run with the specified quantization type.
 
 While there are [a number of quantization types available](https://github.com/ggerganov/llama.cpp/pull/7527), Ollama currently supports:
 

--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -142,8 +142,6 @@ PARAMETER <parameter> <parametervalue>
 | top_k          | Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative. (Default: 40)                                                                        | int        | top_k 40             |
 | top_p          | Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text. (Default: 0.9)                                                                 | float      | top_p 0.9            |
 | min_p          | Alternative to the top_p, and aims to ensure a balance of quality and variety. The parameter *p* represents the minimum probability for a token to be considered, relative to the probability of the most likely token. For example, with *p*=0.05 and the most likely token having a probability of 0.9, logits with a value less than 0.045 are filtered out. (Default: 0.0) | float      | min_p 0.05            |
-| cache_type_k   | Sets the K/V context cache quantization for keys.   (Default: f16)                                                                                                                                                                                      | string     | cache_type_k q8_0    |
-| cache_type_v   | Sets the K/V context cache quantization for values. (Default: f16)                                                                                                                                                                                      | string     | cache_type_v q8_0    |
 
 ### TEMPLATE
 

--- a/llm/memory.go
+++ b/llm/memory.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/gpu"
 )
@@ -17,7 +18,7 @@ func PredictServerFit(allGpus gpu.GpuInfoList, ggml *GGML, adapters, projectors 
 	var estimatedVRAM uint64
 	for _, gpus := range allGpus.ByLibrary() {
 		var layerCount int
-		estimate := EstimateGPULayers(gpus, ggml, projectors, &opts)
+		estimate := EstimateGPULayers(gpus, ggml, projectors, opts)
 		layerCount, estimatedVRAM = estimate.Layers, estimate.VRAMSize
 		if opts.NumGPU < 0 {
 			if layerCount > 0 && layerCount >= int(ggml.KV().BlockCount()+1) {
@@ -66,7 +67,7 @@ type MemoryEstimate struct {
 
 // Given a model and one or more GPU targets, predict how many layers and bytes we can load, and the total size
 // The GPUs provided must all be the same Library
-func EstimateGPULayers(gpus []gpu.GpuInfo, ggml *GGML, projectors []string, opts *api.Options) MemoryEstimate {
+func EstimateGPULayers(gpus []gpu.GpuInfo, ggml *GGML, projectors []string, opts api.Options) MemoryEstimate {
 	// Graph size for a partial offload, applies to all GPUs
 	var graphPartialOffload uint64
 
@@ -115,9 +116,9 @@ func EstimateGPULayers(gpus []gpu.GpuInfo, ggml *GGML, projectors []string, opts
 		slog.Warn("model missing blk.0 layer size")
 	}
 
-	// Estimate the memory required for K and V caches separately
-	kSize := estimateKvCacheSize(opts.CacheTypeK, uint64(opts.NumCtx), ggml.KV().BlockCount(), ggml.KV().EmbeddingHeadCountK(), ggml.KV().HeadCountKV())
-	vSize := estimateKvCacheSize(opts.CacheTypeV, uint64(opts.NumCtx), ggml.KV().BlockCount(), ggml.KV().EmbeddingHeadCountV(), ggml.KV().HeadCountKV())
+	// Estimate the memory required for K and V caches separately as they can have different quantization types
+	kSize := estimateKvCacheSize(envconfig.CacheTypeK(), uint64(opts.NumCtx), ggml.KV().BlockCount(), ggml.KV().EmbeddingHeadCountK(), ggml.KV().HeadCountKV())
+	vSize := estimateKvCacheSize(envconfig.CacheTypeV(), uint64(opts.NumCtx), ggml.KV().BlockCount(), ggml.KV().EmbeddingHeadCountV(), ggml.KV().HeadCountKV())
 	kv := kSize + vSize
 
 	// KV is proportional to the number of layers
@@ -307,30 +308,6 @@ func EstimateGPULayers(gpus []gpu.GpuInfo, ggml *GGML, projectors []string, opts
 	return estimate
 }
 
-// estimateKvCacheSize determines the memory required for K or V cache based on the quantization type
-func estimateKvCacheSize(cacheType string, numCtx, blockCount, embeddingHeadCount, headCountKV uint64) uint64 {
-	var bytesPerElement float64
-
-	switch cacheType {
-	case "f32", "fp32":
-		bytesPerElement = 4 // fp32
-	case "", "f16", "fp16":
-		bytesPerElement = 2 // fp16
-	case "q4_0":
-		bytesPerElement = 0.5 // 1/4 of fp16
-	case "q8_0":
-		bytesPerElement = 1 // 1/2 of fp16
-	default:
-		// Default to fp16 if unknown
-		bytesPerElement = 2
-		slog.Warn("Unknown cache type, defaulting to fp16", "type", cacheType)
-	}
-
-	estimate := uint64(float64(numCtx*blockCount*embeddingHeadCount*headCountKV) * bytesPerElement)
-	// round up to the nearest multiple of 64 bytes
-	return ((estimate + 63) / 64) * 64
-}
-
 func (m MemoryEstimate) log() {
 	slog.Info(
 		"offload to "+m.inferenceLibrary,
@@ -378,4 +355,28 @@ func (m MemoryEstimate) log() {
 			),
 		),
 	)
+}
+
+// estimateKvCacheSize determines the memory required for K or V cache based on the quantization type
+func estimateKvCacheSize(cacheType string, numCtx, blockCount, embeddingHeadCount, headCountKV uint64) uint64 {
+	var bytesPerElement float64
+
+	switch cacheType {
+	case "f32", "fp32":
+		bytesPerElement = 4 // fp32
+	case "", "f16", "fp16":
+		bytesPerElement = 2 // fp16
+	case "q4_0":
+		bytesPerElement = 0.5 // 1/4 of fp16
+	case "q8_0":
+		bytesPerElement = 1 // 1/2 of fp16
+	default:
+		// Default to fp16 if unknown
+		bytesPerElement = 2
+		slog.Warn("Unknown cache type, defaulting to fp16", "type", cacheType)
+	}
+
+	estimate := uint64(float64(numCtx*blockCount*embeddingHeadCount*headCountKV) * bytesPerElement)
+	// round up to the nearest multiple of 64 bytes
+	return ((estimate + 63) / 64) * 64
 }

--- a/llm/memory_test.go
+++ b/llm/memory_test.go
@@ -58,7 +58,7 @@ func TestEstimateGPULayers(t *testing.T) {
 	projectors := []string{}
 	opts := api.DefaultOptions()
 	t.Run("cpu", func(t *testing.T) {
-		estimate := EstimateGPULayers(gpus, ggml, projectors, &opts)
+		estimate := EstimateGPULayers(gpus, ggml, projectors, opts)
 		assert.Equal(t, 0, estimate.Layers)
 		assert.Equal(t, uint64(0), estimate.Graph)
 	})
@@ -109,7 +109,7 @@ func TestEstimateGPULayers(t *testing.T) {
 			gpus[1].FreeMemory += gpuMinimumMemory + layerSize + s.layer1*layerSize + 1
 			gpus[0].FreeMemory += max(graphFullOffload, graphPartialOffload)
 			gpus[1].FreeMemory += max(graphFullOffload, graphPartialOffload)
-			estimate := EstimateGPULayers(gpus, ggml, projectors, &opts)
+			estimate := EstimateGPULayers(gpus, ggml, projectors, opts)
 			assert.Equal(t, int(s.expect0+s.expect1), estimate.Layers, "scenario %d: %v", i, s)
 			assert.Equal(t, fmt.Sprintf("%d,%d", s.expect0, s.expect1), estimate.TensorSplit, "scenario %d: %v", i, s)
 			var layerSums uint64

--- a/llm/server.go
+++ b/llm/server.go
@@ -82,7 +82,7 @@ func LoadModel(model string, maxArraySize int) (*GGML, error) {
 }
 
 // setCacheTypeParams sets the K/V cache type parameters if specified
-func setCacheTypeParams(params *[]string, opts api.Options, flashAttnEnabled bool) {
+func setCacheTypeParams(params *[]string, flashAttnEnabled bool) {
 	// K/V cache quantization types supported by llama.cpp server
 	validKVCacheTypes := map[string]bool{
 		"f16": true, "f32": true, "q8_0": true, "q4_0": true,
@@ -275,7 +275,7 @@ func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, pr
 		params = append(params, "--flash-attn")
 	}
 
-	setCacheTypeParams(&params, opts, flashAttnEnabled)
+	setCacheTypeParams(&params, flashAttnEnabled)
 
 	// Windows CUDA should not use mmap for best performance
 	// Linux  with a model larger than free space, mmap leads to thrashing

--- a/llm/server.go
+++ b/llm/server.go
@@ -61,17 +61,6 @@ type llmServer struct {
 	sem *semaphore.Weighted
 }
 
-// selectStr returns the first non-empty value in a list of strings
-// (e.g. selectStr("", "foo", "bar") -> "foo")
-func selectStr(values ...string) string {
-	for _, v := range values {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
-}
-
 // LoadModel will load a model from disk. The model must be in the GGML format.
 //
 // It collects array values for arrays with a size less than or equal to
@@ -93,7 +82,7 @@ func LoadModel(model string, maxArraySize int) (*GGML, error) {
 }
 
 // setCacheTypeParams sets the K/V cache type parameters if specified
-func setCacheTypeParams(params *[]string, opts *api.Options, flashAttnEnabled bool) {
+func setCacheTypeParams(params *[]string, opts api.Options, flashAttnEnabled bool) {
 	// K/V cache quantization types supported by llama.cpp server
 	validKVCacheTypes := map[string]bool{
 		"f16": true, "f32": true, "q8_0": true, "q4_0": true,
@@ -123,8 +112,8 @@ func setCacheTypeParams(params *[]string, opts *api.Options, flashAttnEnabled bo
 	}
 
 	// Determine cache types, prioritizing parameter options and set cache type parameters
-	setCacheTypeParam("--cache-type-k", selectStr(opts.CacheTypeK, envconfig.CacheTypeK()))
-	setCacheTypeParam("--cache-type-v", selectStr(opts.CacheTypeV, envconfig.CacheTypeV()))
+	setCacheTypeParam("--cache-type-k", envconfig.CacheTypeK())
+	setCacheTypeParam("--cache-type-v", envconfig.CacheTypeV())
 }
 
 // NewLlamaServer will run a server for the given GPUs
@@ -153,9 +142,9 @@ func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, pr
 	}
 	if len(gpus) == 1 && gpus[0].Library == "cpu" {
 		cpuRunner = serverForCpu()
-		estimate = EstimateGPULayers(gpus, ggml, projectors, &opts)
+		estimate = EstimateGPULayers(gpus, ggml, projectors, opts)
 	} else {
-		estimate = EstimateGPULayers(gpus, ggml, projectors, &opts)
+		estimate = EstimateGPULayers(gpus, ggml, projectors, opts)
 
 		switch {
 		case gpus[0].Library == "metal" && estimate.VRAMSize > systemTotalMemory:
@@ -286,7 +275,7 @@ func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, pr
 		params = append(params, "--flash-attn")
 	}
 
-	setCacheTypeParams(&params, &opts, flashAttnEnabled)
+	setCacheTypeParams(&params, opts, flashAttnEnabled)
 
 	// Windows CUDA should not use mmap for best performance
 	// Linux  with a model larger than free space, mmap leads to thrashing
@@ -791,8 +780,6 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 		"penalize_nl":       req.Options.PenalizeNewline,
 		"seed":              req.Options.Seed,
 		"stop":              req.Options.Stop,
-		"cache_type_k":      req.Options.CacheTypeK,
-		"cache_type_v":      req.Options.CacheTypeV,
 		"image_data":        req.Images,
 		"cache_prompt":      true,
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -28,7 +28,7 @@ TEMPLATE """{{ if .System }}<|start_header_id|>system<|end_header_id|>
 
 {{ .Prompt }}<|eot_id|>{{ end }}<|start_header_id|>assistant<|end_header_id|>
 
-{{ .Response }}<|eot_id|>"""
+{{ .Response }}<|eot_id|>"""    
 `
 
 	reader := strings.NewReader(input)
@@ -61,7 +61,7 @@ TEMPLATE """   {{ if .System }}<|start_header_id|>system<|end_header_id|>
 
 {{ .Prompt }}<|eot_id|>{{ end }}<|start_header_id|>assistant<|end_header_id|>
 
-{{ .Response }}<|eot_id|>   """
+{{ .Response }}<|eot_id|>   """    
 `
 
 	reader := strings.NewReader(input)
@@ -440,8 +440,7 @@ func TestParseFileParameters(t *testing.T) {
 		"num_gpu 1":                    {"num_gpu", "1"},
 		"main_gpu 1":                   {"main_gpu", "1"},
 		"low_vram true":                {"low_vram", "true"},
-		"cache_type_k f16":             {"cache_type_k", "f16"},
-		"cache_type_v f16":             {"cache_type_v", "f16"},
+		"f16_kv true":                  {"f16_kv", "true"},
 		"logits_all true":              {"logits_all", "true"},
 		"vocab_only true":              {"vocab_only", "true"},
 		"use_mmap true":                {"use_mmap", "true"},

--- a/server/routes.go
+++ b/server/routes.go
@@ -95,7 +95,7 @@ func (s *Server) scheduleRunner(ctx context.Context, name string, caps []Capabil
 		return nil, nil, nil, err
 	}
 
-	runnerCh, errCh := s.sched.GetRunner(ctx, model, &opts, keepAlive)
+	runnerCh, errCh := s.sched.GetRunner(ctx, model, opts, keepAlive)
 	var runner *runnerRef
 	select {
 	case runner = <-runnerCh:

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -38,11 +38,10 @@ func TestLoad(t *testing.T) {
 	defer done()
 	s := InitScheduler(ctx)
 	var ggml *llm.GGML // value not used in tests
-	defaultOpts := api.DefaultOptions()
 	req := &LlmRequest{
 		ctx:             ctx,
 		model:           &Model{ModelPath: "foo"},
-		opts:            &defaultOpts,
+		opts:            api.DefaultOptions(),
 		successCh:       make(chan *runnerRef, 1),
 		errCh:           make(chan error, 1),
 		sessionDuration: &api.Duration{Duration: 2 * time.Second},
@@ -140,11 +139,10 @@ func newScenarioRequest(t *testing.T, ctx context.Context, modelName string, est
 	if duration == nil {
 		duration = &api.Duration{Duration: 5 * time.Millisecond}
 	}
-	defaultOpts := api.DefaultOptions()
 	b.req = &LlmRequest{
 		ctx:             b.ctx,
 		model:           model,
-		opts:            &defaultOpts,
+		opts:            api.DefaultOptions(),
 		sessionDuration: duration,
 		successCh:       make(chan *runnerRef, 1),
 		errCh:           make(chan error, 1),
@@ -458,10 +456,9 @@ func TestPrematureExpired(t *testing.T) {
 
 func TestUseLoadedRunner(t *testing.T) {
 	ctx, done := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defaultOpts := api.DefaultOptions()
 	req := &LlmRequest{
 		ctx:             ctx,
-		opts:            &defaultOpts,
+		opts:            api.DefaultOptions(),
 		successCh:       make(chan *runnerRef, 1),
 		sessionDuration: &api.Duration{Duration: 2},
 	}
@@ -586,13 +583,12 @@ func TestNeedsReload(t *testing.T) {
 		llama:       llm,
 		numParallel: 1,
 	}
-	defaultOpts := api.DefaultOptions()
 	req := &LlmRequest{
 		model: &Model{
 			AdapterPaths:   []string{"adapter2"},
 			ProjectorPaths: []string{"projector2"},
 		},
-		opts: &defaultOpts,
+		opts: api.DefaultOptions(),
 	}
 	resp := runner.needsReload(ctx, req)
 	require.True(t, resp)


### PR DESCRIPTION
Remove the ability to set cache types by API, Modelfile or cmd as requested.